### PR TITLE
Functionality for additional custom DownloaderData Json Uris

### DIFF
--- a/Source/PluginDownloaderEditor/Private/PluginDownloaderApi.h
+++ b/Source/PluginDownloaderEditor/Private/PluginDownloaderApi.h
@@ -14,7 +14,11 @@ extern FSimpleMulticastDelegate GOnPluginDownloaderRemoteInfosChanged;
 
 struct FPluginDownloaderApi
 {
+	static int NumberOfRepos = 1;
+	static int NumberOfReposProcessed = 0;
+	
 	static void Initialize();
+	static void OnProcessedDownloaderDataEntry();
 	static void FixupBranchName(FString& BranchName);
 
 	static void GetRepoAutocomplete(const FPluginDownloaderInfo& Info, FOnAutocompleteReceived OnAutocompleteReceived, bool bIsOrganization = true);

--- a/Source/PluginDownloaderEditor/Public/PluginDownloaderSettings.h
+++ b/Source/PluginDownloaderEditor/Public/PluginDownloaderSettings.h
@@ -30,6 +30,9 @@ public:
 	UPROPERTY(Config, EditAnywhere, Category = "Plugin Downloader")
     bool bShowVoxelPluginDevVersions = false;
 
+	UPROPERTY(Config, EditAnywhere, Category = "Plugin Downloader")
+    TArray<FString> CustomPluginDownloaderDataJsonUris;
+
     //~ Begin UDeveloperSettings Interface
     virtual FName GetContainerName() const override;
     virtual void PostInitProperties() override;


### PR DESCRIPTION

- Added plugin property **CustomPluginDownloaderDataJsonUris**
- Updated the FPluginDownloaderApi::Initialize() function to  account for multiple URI requests. 
- It always pulls the one from the original repo. Uesrs can add additional ones if they desire

Steps to use

1. navigate to plugin properties
2. add custom URI (IE: "https://raw.githubusercontent.com/scott-hf/PluginDownloaderData/master/Plugins.json")
3. restart unreal
4. 
![image](https://github.com/user-attachments/assets/d83b7133-eca3-428a-92eb-e84f0969066b)
